### PR TITLE
Adds some more API/etc that Helios needs to compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,12 +121,12 @@ enum AppAction: Equatable {
 struct ApiError: Error, Equatable {}
 ```
 
-Next we model the environment of dependencies this feature needs to do its job. In particular, to fetch a number fact we need to construct an `Effect` value that encapsulates the network request. So that dependency is a function from `Int` to `Effect<String, ApiError>`, where `String` represents the response from the request. Further, the effect will typically do its work on a background thread (as is the case with `URLSession`), and so we need a way to receive the effect's values on the main queue. We do this via a main queue scheduler, which is a dependency that is important to control so that we can write tests. We must use an `AnyScheduler` so that we can use a live `DispatchQueue` in production and a test scheduler in tests.
+Next we model the environment of dependencies this feature needs to do its job. In particular, to fetch a number fact we need to construct an `Effect` value that encapsulates the network request. So that dependency is a function from `Int` to `Effect<String>`, where `String` represents the response from the request. Further, the effect will typically do its work on a background thread (as is the case with `URLSession`), and so we need a way to receive the effect's values on the main queue. We do this via a main queue scheduler, which is a dependency that is important to control so that we can write tests. We must use an `AnyScheduler` so that we can use a live `DispatchQueue` in production and a test scheduler in tests.
 
 ```swift
 struct AppEnvironment {
   var mainQueue: AnySchedulerOf<DispatchQueue>
-  var numberFact: (Int) -> Effect<String, ApiError>
+  var numberFact: (Int) -> Effect<String>
 }
 ```
 

--- a/Sources/ComposableArchitecture/Internal/Deprecations.swift
+++ b/Sources/ComposableArchitecture/Internal/Deprecations.swift
@@ -1,0 +1,19 @@
+import RxSwift
+
+// NB: Deprecated after 0.1.3:
+
+extension Effect {
+    @available(*, unavailable, renamed: "run")
+    public static func async(
+        _ work: @escaping (AnyObserver<Output>) -> Disposable
+    ) -> Self {
+        self.run(work)
+    }
+}
+
+extension Effect {
+    @available(*, unavailable, renamed: "catching")
+    public static func sync(_ work: @escaping () throws -> Output) -> Self {
+        self.catching(work)
+    }
+}

--- a/Sources/ComposableArchitecture/Testing/TestStore.swift
+++ b/Sources/ComposableArchitecture/Testing/TestStore.swift
@@ -53,7 +53,7 @@
   ///     }
   ///     struct SearchEnvironment {
   ///       var mainQueue: AnySchedulerOf<DispatchQueue>
-  ///       var request: (String) -> Effect<[String], Never>
+  ///       var request: (String) -> Effect<[String]>
   ///     }
   ///     let searchReducer = Reducer<
   ///       SearchState, SearchAction, SearchEnvironment

--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -79,4 +79,72 @@ extension Store {
   ) -> Disposable where State == Wrapped? {
     self.ifLet(then: unwrap, else: {})
   }
+
+  /// Subscribes to updates when a store containing optional state goes from `nil` to non-`nil` or
+  /// non-`nil` to `nil`.
+  ///
+  /// This is useful for handling navigation in UIKit. The state for a screen that you want to
+  /// navigate to can be held as an optional value in the parent, and when that value switches
+  /// from `nil` to non-`nil` you want to trigger a navigation and hand the detail view a `Store`
+  /// whose domain has been scoped to just that feature:
+  ///
+  ///     class MasterViewController: UIViewController {
+  ///       let store: Store<MasterState, MasterAction>
+  ///       var cancellables: Set<AnyCancellable> = []
+  ///       ...
+  ///       func viewDidLoad() {
+  ///         ...
+  ///         self.store
+  ///           .scope(state: \.optionalDetail, action: MasterAction.detail)
+  ///           .ifLet(
+  ///             then: { [weak self] detailStore in
+  ///               self?.navigationController?.pushViewController(
+  ///                 DetailViewController(store: detailStore),
+  ///                 animated: true
+  ///               )
+  ///             },
+  ///             else: { [weak self] in
+  ///               guard let self = self else { return }
+  ///               self.navigationController?.popToViewController(self, animated: true)
+  ///             }
+  ///           )
+  ///           .store(in: &self.cancellables)
+  ///       }
+  ///     }
+  ///
+  /// - Parameters:
+  ///   - unwrap: A function that is called with a store of non-optional state whenever the store's
+  ///     optional state goes from `nil` to non-`nil`.
+  ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
+  ///     `nil`.
+  /// - Returns: A cancellable associated with the underlying subscription.
+  func ifLet<Wrapped>(
+    then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
+    else: @escaping () -> Void = {},
+    onDisposed: @escaping () -> Void = {}
+  ) -> Disposable where State == Wrapped? {
+
+    let elseDisposable =
+      self
+      .scope(
+        state: { state in
+          state.distinctUntilChanged({ ($0 != nil) == ($1 != nil) })
+        }, action: { $0 }
+      )
+      .subscribe(onNext: { store in
+        if store.state == nil { `else`() }
+      })
+
+    let unwrapDisposable =
+      self
+      .scope(
+        state: { state in
+          state.distinctUntilChanged({ ($0 != nil) == ($1 != nil) })
+            .compactMap { $0 }
+        }, action: { $0 }
+      )
+      .subscribe(onNext: unwrap)
+
+    return CompositeDisposable(elseDisposable, unwrapDisposable, Disposables.create(with: onDisposed))
+  }
 }

--- a/Sources/ComposableArchitecture/ViewStore.swift
+++ b/Sources/ComposableArchitecture/ViewStore.swift
@@ -108,3 +108,10 @@ extension ViewStore where State: Equatable {
     self.init(store, removeDuplicates: ==)
   }
 }
+
+extension ViewStore: ObserverType {
+    public func on(_ event: Event<Action>) {
+        guard let action = event.element else { return }
+        send(action)
+    }
+}


### PR DESCRIPTION
`Effect.catching`, `Effect.run` (adds old methods to `Deprecations.swift`), cleans up some docs.