### PR TITLE
removes unneeded Store.ifLet overrides

### DIFF
--- a/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
+++ b/Sources/ComposableArchitecture/UIKit/IfLetUIKit.swift
@@ -38,85 +38,7 @@ extension Store {
   ///     optional state goes from `nil` to non-`nil`.
   ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
   ///     `nil`.
-  /// - Returns: A cancellable associated with the underlying subscription.
-  public func ifLet<Wrapped>(
-    then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
-    else: @escaping () -> Void
-  ) -> Disposable where State == Wrapped? {
-
-    let elseDisposable =
-      self
-      .scope(
-        state: { state in
-          state.distinctUntilChanged({ ($0 != nil) == ($1 != nil) })
-        }
-      )
-      .subscribe(onNext: { store in
-        if store.state == nil { `else`() }
-      })
-
-    let unwrapDisposable =
-      self
-      .scope(
-        state: { state in
-          state.distinctUntilChanged({ ($0 != nil) == ($1 != nil) })
-            .compactMap { $0 }
-        }
-      )
-      .subscribe(onNext: unwrap)
-
-    return CompositeDisposable(elseDisposable, unwrapDisposable)
-  }
-
-  /// An overload of `ifLet(then:else:)` for the times that you do not want to handle the `else`
-  /// case.
-  ///
-  /// - Parameter unwrap: A function that is called with a store of non-optional state whenever the
-  ///   store's optional state goes from `nil` to non-`nil`.
-  /// - Returns: A cancellable associated with the underlying subscription.
-  public func ifLet<Wrapped>(
-    then unwrap: @escaping (Store<Wrapped, Action>) -> Void
-  ) -> Disposable where State == Wrapped? {
-    self.ifLet(then: unwrap, else: {})
-  }
-
-  /// Subscribes to updates when a store containing optional state goes from `nil` to non-`nil` or
-  /// non-`nil` to `nil`.
-  ///
-  /// This is useful for handling navigation in UIKit. The state for a screen that you want to
-  /// navigate to can be held as an optional value in the parent, and when that value switches
-  /// from `nil` to non-`nil` you want to trigger a navigation and hand the detail view a `Store`
-  /// whose domain has been scoped to just that feature:
-  ///
-  ///     class MasterViewController: UIViewController {
-  ///       let store: Store<MasterState, MasterAction>
-  ///       var cancellables: Set<AnyCancellable> = []
-  ///       ...
-  ///       func viewDidLoad() {
-  ///         ...
-  ///         self.store
-  ///           .scope(state: \.optionalDetail, action: MasterAction.detail)
-  ///           .ifLet(
-  ///             then: { [weak self] detailStore in
-  ///               self?.navigationController?.pushViewController(
-  ///                 DetailViewController(store: detailStore),
-  ///                 animated: true
-  ///               )
-  ///             },
-  ///             else: { [weak self] in
-  ///               guard let self = self else { return }
-  ///               self.navigationController?.popToViewController(self, animated: true)
-  ///             }
-  ///           )
-  ///           .store(in: &self.cancellables)
-  ///       }
-  ///     }
-  ///
-  /// - Parameters:
-  ///   - unwrap: A function that is called with a store of non-optional state whenever the store's
-  ///     optional state goes from `nil` to non-`nil`.
-  ///   - else: A function that is called whenever the store's optional state goes from non-`nil` to
-  ///     `nil`.
+  ///   - onDisposed: A function that is called when the returned Disposable is disposed.
   /// - Returns: A cancellable associated with the underlying subscription.
   public func ifLet<Wrapped>(
     then unwrap: @escaping (Store<Wrapped, Action>) -> Void,
@@ -129,7 +51,7 @@ extension Store {
       .scope(
         state: { state in
           state.distinctUntilChanged({ ($0 != nil) == ($1 != nil) })
-        }, action: { $0 }
+        }
       )
       .subscribe(onNext: { store in
         if store.state == nil { `else`() }
@@ -141,7 +63,7 @@ extension Store {
         state: { state in
           state.distinctUntilChanged({ ($0 != nil) == ($1 != nil) })
             .compactMap { $0 }
-        }, action: { $0 }
+        }
       )
       .subscribe(onNext: unwrap)
 


### PR DESCRIPTION
Helios requires the one with `onDisposed`, which includes default args that made the other overloads redundant.