### PR TITLE
Effect.timer cancels previously in-flight actions

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Timer.swift
+++ b/Sources/ComposableArchitecture/Effects/Timer.swift
@@ -37,6 +37,6 @@ extension Effect where Output: RxAbstractInteger {
       Observable
       .interval(interval, scheduler: scheduler)
       .eraseToEffect()
-      .cancellable(id: id)
+      .cancellable(id: id, cancelInFlight: true)
   }
 }


### PR DESCRIPTION
This follows the behavior of the upstream PointFree fork.