### PR TITLE
scope & ViewState equality perf

### DIFF
--- a/Sources/ComposableArchitecture/Effects/Cancellation.swift
+++ b/Sources/ComposableArchitecture/Effects/Cancellation.swift
@@ -52,15 +52,7 @@ extension Effect {
       defer { cancellablesLock.unlock() }
 
       let subject = PublishSubject<Output>()
-      var values: [Output] = []
-      var isCaching = true
-      let disposable =
-        self
-        .do(onNext: { val in
-          guard isCaching else { return }
-          values.append(val)
-        })
-        .subscribe(subject)
+      let disposable = self.subscribe(subject)
 
       var cancellationDisposable: AnyDisposable!
       cancellationDisposable = AnyDisposable(
@@ -79,12 +71,10 @@ extension Effect {
         cancellationDisposable
       )
 
-      return Observable.from(values)
-        .concat(subject)
+      return subject
         .do(
           onError: { _ in cancellationDisposable.dispose() },
           onCompleted: cancellationDisposable.dispose,
-          onSubscribed: { isCaching = false },
           onDispose: cancellationDisposable.dispose
         )
     }


### PR DESCRIPTION
Elides a bunch of equality checks in view-state evaluation and in scoping, by moving some redundancy/distinctness checks further up the chain, and by avoiding evaluating states that have already been evaluated.

These changes are covered in https://www.pointfree.co/episodes/ep151-composable-architecture-performance-view-stores-and-scoping#t1234