### PR TITLE
Store.scope: supports overrideSendingQueue

### DIFF
--- a/ComposableArchitecture.podspec
+++ b/ComposableArchitecture.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ComposableArchitecture'
-  s.version          = '0.8.8'
+  s.version          = '0.8.9'
   s.summary          = 'A RxSwift fork of The Composable Architecture.'
 
   s.description      = <<-DESC


### PR DESCRIPTION
`Store.scope(…)` now allows setting the `sendingQueue` for the `Store` created.