### PR TITLE
Update Cancel Effects to fix RxSwift Reentrancy (and update to the latest PF code on cancel effects).

### DIFF
--- a/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
+++ b/Tests/ComposableArchitectureTests/EffectCancellationTests.swift
@@ -11,6 +11,7 @@ final class EffectCancellationTests: XCTestCase {
   override func tearDown() {
     super.tearDown()
     disposeBag = DisposeBag()
+    cancellationCancellables.removeAll()
   }
 
   func testCancellation() {


### PR DESCRIPTION
Hestia was getting some RxSwift reentrancy issues _only when an Effect was cancellable_. 

The issue came down that we were doing `onComplete` instead of `afterComplete`, which caused us to push out an event before our original `onComplete` was finished.

While there, I updated the code to use the latest head in TCA PF for cancellables. This made expressing the code much simpler.

All tests in `EffectCancellationTests` are still passing (and they weren't originally. Thank u unit tests).

